### PR TITLE
Fix rails-5.2

### DIFF
--- a/lib/slugger.rb
+++ b/lib/slugger.rb
@@ -19,10 +19,11 @@ module Slugger
       self.slugger_options = default_options.merge(options)
       self.slugger_options[:title_column] = title_column unless title_column.nil?
 
-      migrator = 
+      migrator =
         ActiveRecord::Migrator.new(
-          :up, 
-          ActiveRecord::Migrator.migrations(ActiveRecord::Migrator.migrations_paths.first)
+          :up,
+          ActiveRecord::MigrationContext.new(ActiveRecord::Migrator.migrations_paths.first).migrations
+          # ActiveRecord::Migrator.migrations(ActiveRecord::Migrator.migrations_paths.first)
         )
 
       if table_exists? && migrator.pending_migrations.blank? && columns_hash[slugger_options[:slug_column].to_s].nil?


### PR DESCRIPTION
undefined method `migrations' for ActiveRecord::Migrator:Class
`https://github.com/rails/rails/commit/a2827ec9811b5012e8e366011fd44c8eb53fc714#diff-8d3c44120f7b67ff79e2fbe6a40d0ad6L1005`